### PR TITLE
Include @somewherewarm path in all loaders in the watch and build process

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,9 @@
 *** SomewhereWarm WooCommerce Packages ***
 
-2021-09-21 - version 1.1.1
+2022-01-31 - version 1.0.2
+* Fix - Fixed the exclusions for all module loaders in watch context.
+
+2021-09-21 - version 1.0.1
 * Fix - Fixed issues with 'getReportChartData' selector in WooCommerce Admin gte 2.6.0.
 
 2020-11-13 - version 1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@somewherewarm/woocommerce",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Collection of WooCommerce packages",
   "main": "index.js",
   "scripts": {

--- a/packages/dependency-manager/config/webpack.config.js
+++ b/packages/dependency-manager/config/webpack.config.js
@@ -5,8 +5,23 @@ const path                           = require( 'path' );
 // Disable minification. It will be minimized in Grunt Uglify task.
 defaultConfig.optimization.minimize = false;
 
-// Allow babel-loader to process @somewherewarm files as well.
-defaultConfig.module.rules[0].exclude = /node_modules\/(?!@somewherewarm).*/;
+// Include node_modules/@somewherewarm scripts in all loaders.
+for ( var key in defaultConfig.module.rules ) {
+
+	if ( ! defaultConfig.module.rules.hasOwnProperty( key ) ) {
+		continue;
+	}
+
+	var rule = defaultConfig.module.rules[ key ];
+	for ( var prop in rule ) {
+
+		if ( ! rule.hasOwnProperty( prop ) || prop !== 'exclude' ) {
+			continue;
+		}
+
+		defaultConfig.module.rules[ key ][ prop ] = /node_modules\/(?!@somewherewarm).*/;
+	}
+}
 
 // Attach front-end deps.
 const wcDepMap = {


### PR DESCRIPTION
Closes #3 

### Specification

The `watch` command requires first loading the source-maps before handling the babel syntax. This PR adds the `@somewherewarm` package exclusion in all module loaders.