### PR TITLE
React 19 readiness: replace defaultProps with merge in ReportTable, drop propTypes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** SomewhereWarm WooCommerce Packages ***
 
+2026-05-28 - version 1.1.1
+* Fix - React 19 readiness: replaced 'defaultProps' on the ReportTable function component with a props merge and removed redundant prop-types declarations.
+
 2022-03-18 - version 1.1.0
 * Feature - Added MiniCssExtractPlugin support for handling SASS files.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@somewherewarm/woocommerce",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Collection of WooCommerce packages",
   "main": "index.js",
   "scripts": {

--- a/packages/components/report-chart/index.js
+++ b/packages/components/report-chart/index.js
@@ -7,7 +7,6 @@ import { compose } from '@wordpress/compose';
 import { format as formatDate } from '@wordpress/date';
 import { withSelect } from '@wordpress/data';
 import { get, isEqual } from 'lodash';
-import PropTypes from 'prop-types';
 
 /**
  * WooCommerce dependencies
@@ -259,88 +258,6 @@ export class ReportChart extends Component {
 }
 
 ReportChart.contextType = CurrencyContext;
-
-ReportChart.propTypes = {
-
-	/**
-	 * Filters available for that report.
-	 */
-	filters: PropTypes.array,
-
-	/**
-	 * Whether there is an API call running.
-	 */
-	isRequesting: PropTypes.bool,
-
-	/**
-	 * Label describing the legend items.
-	 */
-	itemsLabel: PropTypes.string,
-
-	/**
-	 * Allows specifying properties different from the `endpoint` that will be used
-	 * to limit the items when there is an active search.
-	 */
-	limitProperties: PropTypes.array,
-
-	/**
-	 * `items-comparison` (default) or `time-comparison`, this is used to generate correct
-	 * ARIA properties.
-	 */
-	mode: PropTypes.string,
-
-	/**
-	 * Current path
-	 */
-	path: PropTypes.string.isRequired,
-
-	/**
-	 * Primary data to display in the chart.
-	 */
-	primaryData: PropTypes.object,
-
-	/**
-	 * The query string represented in object form.
-	 */
-	query: PropTypes.object.isRequired,
-
-	/**
-	 * Secondary data to display in the chart.
-	 */
-	secondaryData: PropTypes.object,
-
-	/**
-	 * Properties of the selected chart.
-	 */
-	selectedChart: PropTypes.shape( {
-
-		/**
-		 * Key of the selected chart.
-		 */
-		key: PropTypes.string.isRequired,
-
-		/**
-		 * Chart label.
-		 */
-		label: PropTypes.string.isRequired,
-
-		/**
-		 * Order query argument.
-		 */
-		order: PropTypes.oneOf( [ 'asc', 'desc' ] ),
-
-		/**
-		 * Order by query argument.
-		 */
-		orderby: PropTypes.string,
-
-		/**
-		 * Number type for formatting.
-		 */
-		type: PropTypes.oneOf( [ 'average', 'number', 'currency' ] ).isRequired,
-
-	} ).isRequired,
-};
 
 ReportChart.defaultProps = {
 	isRequesting: false,

--- a/packages/components/report-error/index.js
+++ b/packages/components/report-error/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import PropTypes from 'prop-types';
 import { EmptyContent } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/settings';
 
@@ -44,24 +43,6 @@ class ReportError extends Component {
 		);
 	}
 }
-
-ReportError.propTypes = {
-
-	/**
-	 * Additional class name to style the component.
-	 */
-	className: PropTypes.string,
-
-	/**
-	 * Boolean representing whether there was an error.
-	 */
-	isError: PropTypes.bool,
-
-	/**
-	 * Boolean representing whether the issue is that there is no data.
-	 */
-	isEmpty: PropTypes.bool,
-};
 
 ReportError.defaultProps = {
 	className: '',

--- a/packages/components/report-summary/index.js
+++ b/packages/components/report-summary/index.js
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-import PropTypes from 'prop-types';
 
 /**
  * WooCommerce dependencies
@@ -118,61 +117,6 @@ export class ReportSummary extends Component {
 		return <SummaryList>{ renderSummaryNumbers }</SummaryList>;
 	}
 }
-
-ReportSummary.propTypes = {
-	/**
-	 * Properties of all the charts available for that report.
-	 */
-	charts: PropTypes.array.isRequired,
-	/**
-	 * The endpoint to use in API calls to populate the Summary Numbers.
-	 * For example, if `taxes` is provided, data will be fetched from the report
-	 * `taxes` endpoint (ie: `/wc-analytics/reports/taxes/stats`). If the provided endpoint
-	 * doesn't exist, an error will be shown to the user with `ReportError`.
-	 */
-	endpoint: PropTypes.string.isRequired,
-
-	/**
-	 * The query string represented in object form.
-	 */
-	query: PropTypes.object.isRequired,
-
-	/**
-	 * Properties of the selected chart.
-	 */
-	selectedChart: PropTypes.shape( {
-		/**
-		 * Key of the selected chart.
-		 */
-		key: PropTypes.string.isRequired,
-		/**
-		 * Chart label.
-		 */
-		label: PropTypes.string.isRequired,
-		/**
-		 * Order query argument.
-		 */
-		order: PropTypes.oneOf( [ 'asc', 'desc' ] ),
-		/**
-		 * Order by query argument.
-		 */
-		orderby: PropTypes.string,
-		/**
-		 * Number type for formatting.
-		 */
-		type: PropTypes.oneOf( [ 'average', 'number', 'currency' ] ).isRequired,
-	} ).isRequired,
-
-	/**
-	 * Data to display in the SummaryNumbers.
-	 */
-	summaryData: PropTypes.object,
-
-	/**
-	 * Report name, if different than the endpoint.
-	 */
-	report: PropTypes.string,
-};
 
 ReportSummary.defaultProps = {
 	summaryData: {

--- a/packages/components/report-table/index.js
+++ b/packages/components/report-table/index.js
@@ -9,7 +9,6 @@ import { focus } from '@wordpress/dom';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { get, noop, partial, uniq } from 'lodash';
 import { __, sprintf } from '@wordpress/i18n';
-import PropTypes from 'prop-types';
 import { CompareButton, Search, TableCard } from '@woocommerce/components';
 import {
 	getIdsFromQuery,
@@ -41,7 +40,25 @@ import { extendTableData } from './utils';
 
 const TABLE_FILTER = 'woocommerce_admin_report_table';
 
-const ReportTable = ( props ) => {
+const ReportTable = ( rawProps ) => {
+	// React 19 removes defaultProps on function components — apply defaults via merge instead.
+	const props = {
+		primaryData: {},
+		tableData: {
+			items: {
+				data: [],
+				totalResults: 0,
+			},
+			query: {},
+		},
+		tableQuery: {},
+		compareParam: 'filter',
+		downloadable: false,
+		onSearch: noop,
+		baseSearchQuery: {},
+		...rawProps,
+	};
+
 	const {
 		getHeadersContent,
 		getRowsContent,
@@ -414,115 +431,6 @@ const ReportTable = ( props ) => {
 			/>
 		</Fragment>
 	);
-};
-
-ReportTable.propTypes = {
-	/**
-	 * Pass in query parameters to be included in the path when onSearch creates a new url.
-	 */
-	baseSearchQuery: PropTypes.object,
-
-	/**
-	 * The string to use as a query parameter when comparing row items.
-	 */
-	compareBy: PropTypes.string,
-
-	/**
-	 * Url query parameter compare function operates on
-	 */
-	compareParam: PropTypes.string,
-
-	/**
-	 * The key for user preferences settings for column visibility.
-	 */
-	columnPrefsKey: PropTypes.string,
-
-	/**
-	 * The endpoint to use in API calls to populate the table rows and summary.
-	 * For example, if `taxes` is provided, data will be fetched from the report
-	 * `taxes` endpoint (ie: `/wc-analytics/reports/taxes` and `/wc/v4/reports/taxes/stats`).
-	 * If the provided endpoint doesn't exist, an error will be shown to the user
-	 * with `ReportError`.
-	 */
-	endpoint: PropTypes.string,
-
-	/**
-	 * A function that returns the headers object to build the table.
-	 */
-	getHeadersContent: PropTypes.func.isRequired,
-
-	/**
-	 * A function that returns the rows array to build the table.
-	 */
-	getRowsContent: PropTypes.func.isRequired,
-
-	/**
-	 * A function that returns the summary object to build the table.
-	 */
-	getSummary: PropTypes.func,
-
-	/**
-	 * The name of the property in the item object which contains the id.
-	 */
-	itemIdField: PropTypes.string,
-
-	/**
-	 * Custom labels for table header actions.
-	 */
-	labels: PropTypes.shape( {
-		compareButton: PropTypes.string,
-		downloadButton: PropTypes.string,
-		helpText: PropTypes.string,
-		placeholder: PropTypes.string,
-	} ),
-
-	/**
-	 * Primary data of that report. If it's not provided, it will be automatically
-	 * loaded via the provided `endpoint`.
-	 */
-	primaryData: PropTypes.object,
-
-	/**
-	 * The string to use as a query parameter when searching row items.
-	 */
-	searchBy: PropTypes.string,
-
-	/**
-	 * List of fields used for summary numbers. (Reduces queries)
-	 */
-	summaryFields: PropTypes.arrayOf( PropTypes.string ),
-
-	/**
-	 * Table data of that report. If it's not provided, it will be automatically
-	 * loaded via the provided `endpoint`.
-	 */
-	tableData: PropTypes.object.isRequired,
-
-	/**
-	 * Properties to be added to the query sent to the report table endpoint.
-	 */
-	tableQuery: PropTypes.object,
-
-	/**
-	 * String to display as the title of the table.
-	 */
-	title: PropTypes.string.isRequired,
-};
-
-ReportTable.defaultProps = {
-	primaryData: {},
-	tableData: {
-		items: {
-			data: [],
-			totalResults: 0,
-		},
-		query: {},
-	},
-	tableQuery: {},
-	compareParam: 'filter',
-	downloadable: false,
-	onSearch: noop,
-	baseSearchQuery: {},
 };
 
 const EMPTY_ARRAY = [];


### PR DESCRIPTION
Closes [STRPROD-903: Prepare SomewhereWarm Extensions for React 19 upgrade​](https://linear.app/a8c/issue/STRPROD-903/prepare-somewherewarm-extensions-for-react-19-upgrade)

## What?
- React 19 removes `defaultProps` support on function components, so `ReportTable`'s defaults would silently stop applying once the upgrade lands. This prepares the report components ahead of that change.
- Also removes the now-redundant `propTypes` declarations across the report components, which were dev-only runtime checks no longer aligned with our type strategy.

## How?
- In `report-table/index.js`, the function component now merges its defaults into the incoming props (`{ ...defaults, ...rawProps }`) instead of relying on `ReportTable.defaultProps`.
- Dropped the `prop-types` import and the `propTypes`/`defaultProps` blocks from `report-chart`, `report-error`, `report-summary`, and `report-table`.

## Testing Instructions
N/A - Package is shared-source / build on consumers.